### PR TITLE
Feature play and pause

### DIFF
--- a/firmware/app/lib/commUI/commUI.cpp
+++ b/firmware/app/lib/commUI/commUI.cpp
@@ -44,7 +44,7 @@ CommUI::CommandFromUI CommUI::parseCommand(const String& input) {
     }else if (input == "#PAUSE!") {
         return PAUSE_CYCLE;
     }else if (input == "#PLAY!") {
-        return PAUSE_CYCLE;
+        return RESUME_CYCLE;
     }
     // Add more commands as needed
     return UNKNOWN_COMMAND;

--- a/firmware/app/lib/cycle_manager/cycle_manager.cpp
+++ b/firmware/app/lib/cycle_manager/cycle_manager.cpp
@@ -308,7 +308,7 @@ cycle_manager::CycleBundle cycle_manager::run()
     if (alarmFlag) // la alarma solo se va a activar si el ciclo esta corriendo
     {
         alarmFlag = false;
-        ESP_LOGE(TAG, "SE ACTIVO LA ALARMA");
+        ESP_LOGI(TAG, "SE ACTIVO LA ALARMA");
         if (readNextInterval())
         {
             // ESP_LOGI(TAG,"New interval available");
@@ -333,11 +333,14 @@ cycle_manager::CycleBundle cycle_manager::run()
 bool cycle_manager::pauseCycle(){
     cycleAlarm.pauseAlarm();
     cycleData.status = CYCLE_PAUSED;
+    alarmFlag = false;
+    return true;
 }
 
 bool cycle_manager::resumeCycle(){
     cycleAlarm.resumeAlarm();
     cycleData.status = CYCLE_RUNNING;
+    return true;
 }
 
 /**

--- a/firmware/app/src/main.cpp
+++ b/firmware/app/src/main.cpp
@@ -100,7 +100,7 @@ void loop()
         {
             Serial.println("#OK!");
             cm.pauseCycle();
-            sensorControl.turnOffOutputs();            
+            sensorControl.turnOffOutputs();
         }
         else if (cm.cycleData.status == cycle_manager::CYCLE_COMPLETED)
         {
@@ -122,17 +122,17 @@ void loop()
         else if (cm.cycleData.status == cycle_manager::CYCLE_RUNNING)
         {
             Serial.println("#FAIL!");
-            ESP_LOGE(TAG, "Ciclo corriendo, imposible play");        
+            ESP_LOGE(TAG, "Ciclo corriendo, imposible play");
         }
         else if (cm.cycleData.status == cycle_manager::CYCLE_COMPLETED)
         {
             Serial.println("#FAIL!");
-            ESP_LOGE(TAG, "Ciclo completado, imposible play");   
+            ESP_LOGE(TAG, "Ciclo completado, imposible play");
         }
         else if (cm.cycleData.status == cycle_manager::CYCLE_PAUSED)
         {
             Serial.println("#OK!");
-            cm.resumeCycle();   
+            cm.resumeCycle();
         }
         break;
     default:


### PR DESCRIPTION
This pull request includes several important changes to the `commUI` and `cycle_manager` components. The changes focus on fixing command handling, improving logging, and ensuring proper cycle management.

Fixes and improvements to command handling and cycle management:

* [`firmware/app/lib/commUI/commUI.cpp`](diffhunk://#diff-4752f54959a904c3e43474e21a93152e493ba73592dc3e254abf69f1839427e9L47-R47): Corrected the command handling for the `#PLAY!` command to return `RESUME_CYCLE` instead of `PAUSE_CYCLE`.

Logging improvements:

* [`firmware/app/lib/cycle_manager/cycle_manager.cpp`](diffhunk://#diff-45aa61e23874bfe75ea9a3b04c743b14fea78790df5392dd179ff94068e193f3L311-R311): Changed the log level from `ESP_LOGE` to `ESP_LOGI` for the alarm activation message to reflect its informational nature.

Cycle management enhancements:

* [`firmware/app/lib/cycle_manager/cycle_manager.cpp`](diffhunk://#diff-45aa61e23874bfe75ea9a3b04c743b14fea78790df5392dd179ff94068e193f3R336-R343): Updated the `pauseCycle` and `resumeCycle` methods to return `true` upon successful execution and reset the `alarmFlag` in `pauseCycle`.